### PR TITLE
Fix broken main: leftover conflict marker + lingua v1/v2 import mismatch (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Author: Emil-18
 * NVDA compatibility: 2026.1
-* Download: [Stable version](https://github.com/Emil-18/enhanced_language_switching/releases/download/v1.2.4/enhancedLanguageDetection-1.2.4.nvda-addon).
+* Download: [Stable version](https://github.com/Emil-18/enhanced_language_switching/releases/download/v1.3.4/enhancedLanguageDetection-1.3.4.nvda-addon).
 
 This add-on Automaticly detects the language of the text NVDA is about to speak, and uses NVDA's built in auto language switching, if turned on, to sspeak the text in that language.
 
@@ -31,11 +31,12 @@ That add-on stopped working, however, and from it's issues on GitHub, it doesn't
     This is a list of the languages to interpret. If the add-on interprets a text as a language that isn't selected in this list, no auto language switching is done based on the interpretation. No languages are selected by default.
 
 ## Change log.
-### v1.2.4.
+### v1.3.4
 
 This version was made by @heath-toby.
 
-* Added compatibility with NVDA 2026.1.
+* Added compatibility with NVDA 2026.1 (Python 3.13, 64-bit).
+* Upgraded the bundled lingua language-detection library from v1 (pure Python) to v2 (Rust-backed bindings). v2 is considerably faster and more accurate, but the compiled library is much larger, so the packaged add-on download is bigger than before.
 * Added a setting that allows you to specify the minimum amount of words required for the add-on to activate.
 
 ### v1.2.3

--- a/addon/globalPlugins/enhancedLanguageDetection/__init__.py
+++ b/addon/globalPlugins/enhancedLanguageDetection/__init__.py
@@ -8,17 +8,14 @@ addonHandler.initTranslation()
 import os
 import sys
 
-<<<<<<< HEAD
-# Lingua can't be imported with relative import, because it requires submodules that I had to include manualy in the lingua folder
-# so add both the add-on folder as well as the underlying lingua folder, to os.path, import lingua, and remove them again
-addonPath = os.path.dirname(__file__)
-linguaPath = os.path.join(os.path.dirname(__file__), "lingua")
-sys.path.append(addonPath)
-sys.path.append(linguaPath)
-import lingua
-from lingua import lingua
-#sys.path.remove(linguaPath)
-#sys.path.remove(addonPath)
+# Vendored `six` lives next to this __init__.py because langdetect does an
+# absolute `import six`. Put the add-on dir on sys.path so that import resolves,
+# then leave it there for the lifetime of the process — once `six` is in
+# sys.modules it stays cached, but langdetect submodules are imported lazily
+# in some code paths, so removing the path entry is unsafe.
+_addonDir = os.path.dirname(__file__)
+if _addonDir not in sys.path:
+	sys.path.insert(0, _addonDir)
 
 import config
 import globalPluginHandler
@@ -30,6 +27,8 @@ from logHandler import log
 from speech.commands import LangChangeCommand
 from speech.extensions import filter_speechSequence
 from . import langdetect
+from . import lingua
+
 profilePath = os.path.join(os.path.dirname(__file__), "langdetect", "profiles")
 languages = os.listdir(profilePath)
 detector = None


### PR DESCRIPTION
Fixes #11.

The post-merge conflict-resolution after #10 left `main` unable to load in NVDA at all. This PR restores it to a working state.

## What was broken

1. **`__init__.py:11` had a stray `<<<<<<< HEAD` marker** — a Python `SyntaxError`. The module can't be imported, so the add-on is completely dead on `main`.
2. **The lingua import was reverted to the v1 style** (`import lingua` / `from lingua import lingua` + sys.path hack) while the rest of the file uses the **v2-only** `lingua.Language.all()` API. Even with the marker removed it would `AttributeError` at load. The same hunk also dropped the `sys.path` insertion that makes the vendored `six.py` importable (langdetect does an absolute `import six`; NVDA 2026.1 no longer ships it).
3. **Changelog** didn't mention the lingua v1 → v2 upgrade — the largest user-facing change in #10 and the reason the packaged add-on is much larger.
4. **Version inconsistency** — README said `v1.2.4`, `buildVars.py` said `1.3.4`.

## What this PR does

- **`__init__.py`**: restored to exactly the state merged in #10 (`e13177c`). That commit's import block is the working v2 version (relative `from . import lingua`, plus the `sys.path` insert for vendored `six`). I verified `e13177c` is the *only* prior good state and that the botched conflict block was the *only* change your post-merge commits made to this file — so this is a surgical revert of just the breakage, preserving every intentional post-merge edit (there were none to this file). `python -m ast` parses the result cleanly; the broken `main` version does not.
- **`README.md`**: changelog entry now documents the lingua v1 → v2 upgrade and NVDA 2026.1 / Python 3.13 / 64-bit; heading and download link aligned to **v1.3.4** to match `buildVars.py` (`addon_version`, set in your `b7c131b`).

No other files touched. `buildVars.py` is left exactly as you set it (`1.3.4`).

## Not addressed here (out of repo scope)

The lingua v2 wheel ships a ~304 MB compiled `.pyd` that exceeds GitHub's 100 MB per-file limit, so — like lingua v1 — it can't be committed and must be vendored at build/release time:

```
pip download lingua-language-detector --only-binary=:all: \
    --platform win_amd64 --python-version 3.13 \
    --implementation cp --abi cp313 -d <tmp>
# extract the `lingua/` package from the wheel into
# addon/globalPlugins/enhancedLanguageDetection/
```

The packaged `.nvda-addon` will be ~170 MB vs the old ~10 MB — worth a line in the release notes.

## Test plan

- [x] `__init__.py` parses (`ast.parse`) — broken `main` raises `SyntaxError: line 11`, this branch is clean
- [x] No conflict markers anywhere in the tree (`git grep -E '^(<<<<<<<|=======|>>>>>>>)'` is empty)
- [x] Import block matches the verified-working #10 merge state, which has been running in production on a user's NVDA 2026.1 (Daniel/Viktor/Yuri/Jorge voices, settings ring, add-on store rapid scroll, say-all) for over a week with the lingua-v2 package vendored

Disclosure, as on #10: I'm not a programmer by training and used Claude Code to produce this. Happy to adjust anything you'd like changed.